### PR TITLE
Prepare haproxy for Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.8-alpine
+FROM haproxy:2.1.7-alpine
 
 # You almost certainly want to set these
 ENV HAPROXY_PROCESSES 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM haproxy:1.8-alpine
 
 # You almost certainly want to set these
-ENV ETCD_NODE http://127.0.0.1:2379
 ENV HAPROXY_PROCESSES 2
 ENV SYSLOG_SERVER localhost
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM haproxy:2.1.7-alpine
 # You almost certainly want to set these
 ENV HAPROXY_PROCESSES 2
 ENV SYSLOG_SERVER localhost
+ENV ETCD_BASE_KEY /proxy
 
 # Not usually something you set
 ENV CONFD_VERSION 0.16.0

--- a/confd/conf.d/haproxy.toml
+++ b/confd/conf.d/haproxy.toml
@@ -7,4 +7,7 @@ src = "haproxy.tmpl"
 dest = "/usr/local/etc/haproxy/haproxy.cfg"
 
 check_cmd = "/usr/local/sbin/haproxy -c -f {{ .src }}"
-reload_cmd = "/usr/local/sbin/haproxy -f /usr/local/etc/haproxy/haproxy.cfg -D -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)"
+reload_cmd = """/usr/local/sbin/haproxy \
+  -f /usr/local/etc/haproxy/haproxy.cfg \
+  -D -p /var/run/haproxy.pid \
+  -sf $(cat /var/run/haproxy.pid)"""

--- a/confd/conf.d/haproxy.toml
+++ b/confd/conf.d/haproxy.toml
@@ -1,7 +1,5 @@
 [template]
-keys = [
-  "/proxy"
-]
+keys = ["/"]
 
 owner = "haproxy-app"
 mode = "0644"

--- a/confd/templates/haproxy.tmpl
+++ b/confd/templates/haproxy.tmpl
@@ -1,24 +1,24 @@
 global
-{{range gets "/proxy/global"}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/global")}}
     {{replace .Value "\\n" "\n    " -1}}
 {{end}}
 
-{{range gets "/proxy/resolvers/*"}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/resolvers/*")}}
 resolvers {{base .Key}}
     {{replace .Value "\\n" "\n    " -1}}
 {{end}}
 
 defaults
-{{range gets "/proxy/defaults"}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/defaults")}}
     {{replace .Value "\\n" "\n    " -1}}
 {{end}}
 
-{{range gets "/proxy/front-ends/*"}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/front-ends/*")}}
 frontend {{base .Key}}
     {{replace .Value "\\n" "\n    " -1}}
 {{end}}
 
-{{range gets "/proxy/back-ends/*"}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/back-ends/*")}}
 backend {{base .Key}}
     {{replace .Value "\\n" "\n    " -1}}
 {{end}}

--- a/confd/templates/haproxy.tmpl
+++ b/confd/templates/haproxy.tmpl
@@ -1,24 +1,24 @@
 global
-{{range gets (print (getenv "ETCD_BASE_KEY") "/global")}}
-    {{replace .Value "\\n" "\n    " -1}}
-{{end}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/global") -}}
+{{replace .Value "\\n" "\n    " -1}}
+{{end -}}
 
-{{range gets (print (getenv "ETCD_BASE_KEY") "/resolvers/*")}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/resolvers/*") -}}
 resolvers {{base .Key}}
-    {{replace .Value "\\n" "\n    " -1}}
-{{end}}
+{{replace .Value "\\n" "\n    " -1}}
+{{end -}}
 
 defaults
-{{range gets (print (getenv "ETCD_BASE_KEY") "/defaults")}}
-    {{replace .Value "\\n" "\n    " -1}}
-{{end}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/defaults") -}}
+{{replace .Value "\\n" "\n    " -1}}
+{{end -}}
 
-{{range gets (print (getenv "ETCD_BASE_KEY") "/front-ends/*")}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/front-ends/*") -}}
 frontend {{base .Key}}
-    {{replace .Value "\\n" "\n    " -1}}
-{{end}}
+{{replace .Value "\\n" "\n    " -1}}
+{{end -}}
 
-{{range gets (print (getenv "ETCD_BASE_KEY") "/back-ends/*")}}
+{{range gets (print (getenv "ETCD_BASE_KEY") "/back-ends/*") -}}
 backend {{base .Key}}
-    {{replace .Value "\\n" "\n    " -1}}
-{{end}}
+{{replace .Value "\\n" "\n    " -1}}
+{{end -}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,16 +16,7 @@ function config_fail()
 	exit -1
 }
 
-
-# Loop until confd has updated the haproxy config
-n=0
-until confd -onetime -node "$ETCD_NODE"; do
-  if [ "$n" -eq "10" ];  then config_fail; fi
-  echo "[gasbuddy/haproxy-confd] waiting for confd to refresh haproxy.cfg"
-  n=$((n+1))
-  sleep $n
-done
-
+confd -onetime -node "$ETCD_NODE"
 exec confd -watch=true -node "$ETCD_NODE" &
 
 echo "[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy and confd"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 set -eo pipefail
 
-echo "[gasbuddy/haproxy-confd] booting container. ETCD: $ETCD_NODE"
+echo "[gasbuddy/api-haproxy] booting container. ETCD: $ETCD_NODE"
 
 function config_fail()
 {
@@ -28,5 +28,5 @@ done
 
 exec confd -watch=true -node "$ETCD_NODE" &
 
-echo "[gasbuddy/haproxy-confd] Initial HAProxy config created. Starting haproxy and confd"
+echo "[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy and confd"
 /usr/local/sbin/haproxy -f /usr/local/etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,6 @@ then
   exit -1
 fi
 
-/sbin/syslogd -O /dev/stdout
-
 set -eo pipefail
 
 echo "[gasbuddy/haproxy-confd] booting container. ETCD: $ETCD_NODE"


### PR DESCRIPTION
This is mostly just cleaning up code that doesn't seem to do anything or renders things in a sloppy way, but also parameterizing the ETCD_BASE_KEY and ETCD_NODE settings for better portability.