### PR TITLE
Fix config reload function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM haproxy:2.2.0-alpine
 
 # You almost certainly want to set these
-ENV HAPROXY_PROCESSES 2
-ENV SYSLOG_SERVER localhost
 ENV ETCD_BASE_KEY /proxy
 
 # Not usually something you set

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.1.7-alpine
+FROM haproxy:2.2.0-alpine
 
 # You almost certainly want to set these
 ENV HAPROXY_PROCESSES 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ ENV HAPROXY_PID /var/run/haproxy.pid
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 \
     /usr/local/bin/confd
 
-RUN addgroup haproxy-app && adduser -SDHG haproxy-app haproxy-app
-
 RUN chmod u+x /usr/local/bin/confd
 
 ADD entrypoint.sh /docker-entrypoint.sh

--- a/confd/conf.d/haproxy.toml
+++ b/confd/conf.d/haproxy.toml
@@ -7,7 +7,4 @@ src = "haproxy.tmpl"
 dest = "/usr/local/etc/haproxy/haproxy.cfg"
 
 check_cmd = "/usr/local/sbin/haproxy -c -f {{ .src }}"
-reload_cmd = """/usr/local/sbin/haproxy \
-  -f /usr/local/etc/haproxy/haproxy.cfg \
-  -D -p /var/run/haproxy.pid \
-  -sf $(cat /var/run/haproxy.pid)"""
+reload_cmd = """kill -s SIGUSR2 $(cat $HAPROXY_PID)"""

--- a/confd/confd.toml
+++ b/confd/confd.toml
@@ -1,4 +1,3 @@
-interval = 10
 debug = false
 verbose = false
 quiet = true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,20 @@ echo '[gasbuddy/api-haproxy] Booting container.'
 echo "[gasbuddy/api-haproxy] Fetching config from ETCD: $ETCD_NODE"
 
 confd -onetime -sync-only -node "$ETCD_NODE"
-exec confd -watch=true -node "$ETCD_NODE" &
 
 echo '[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy...'
 
-echo "[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy and confd"
-/usr/local/sbin/haproxy -f /usr/local/etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
+# Using & instead of -D so that logs go to stdout
+/usr/local/sbin/haproxy \
+  -f /usr/local/etc/haproxy/haproxy.cfg \
+  -W \
+  -p $HAPROXY_PID &
+
+echo "[gasbuddy/api-haproxy] Waiting for haproxy to come online..."
+
+while [[ ! -f $HAPROXY_PID ]]; do sleep 1; done
+
 echo "[gasbuddy/api-haproxy] Started haproxy (PID: $(cat $HAPROXY_PID))"
+echo '[gasbuddy/api-haproxy] Starting confd...'
+
+confd -watch=true -node "$ETCD_NODE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ set -eo pipefail
 echo '[gasbuddy/api-haproxy] Booting container.'
 echo "[gasbuddy/api-haproxy] Fetching config from ETCD: $ETCD_NODE"
 
-confd -onetime -node "$ETCD_NODE"
+confd -onetime -sync-only -node "$ETCD_NODE"
 exec confd -watch=true -node "$ETCD_NODE" &
 
 echo '[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy...'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,8 @@ fi
 
 set -eo pipefail
 
-echo "[gasbuddy/api-haproxy] booting container. ETCD: $ETCD_NODE"
+echo '[gasbuddy/api-haproxy] Booting container.'
+echo "[gasbuddy/api-haproxy] Fetching config from ETCD: $ETCD_NODE"
 
 function config_fail()
 {
@@ -19,5 +20,8 @@ function config_fail()
 confd -onetime -node "$ETCD_NODE"
 exec confd -watch=true -node "$ETCD_NODE" &
 
+echo '[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy...'
+
 echo "[gasbuddy/api-haproxy] Initial HAProxy config created. Starting haproxy and confd"
 /usr/local/sbin/haproxy -f /usr/local/etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
+echo "[gasbuddy/api-haproxy] Started haproxy (PID: $(cat $HAPROXY_PID))"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,12 +11,6 @@ set -eo pipefail
 echo '[gasbuddy/api-haproxy] Booting container.'
 echo "[gasbuddy/api-haproxy] Fetching config from ETCD: $ETCD_NODE"
 
-function config_fail()
-{
-	echo "Failed to start due to config error"
-	exit -1
-}
-
 confd -onetime -node "$ETCD_NODE"
 exec confd -watch=true -node "$ETCD_NODE" &
 


### PR DESCRIPTION
Instead of starting confd and using haproxy as the main process, then attempting to use the haproxy -sf flag in the confd reload_cmd to kill the old haproxy process, we now start haproxy in the background (with `&`) and use confd as the main process (with kill -s HUP $HAPROXY_PID as the reload_cmd)

Other things included in this PR:
- Upstream version bump to 2.2
- Use `nobody` user instead of custom `haproxy-app` (simplifies Dockerfile)
- Fix weird hidden background copy of haproxy by adding `-sync-only` flag to the initial config dump command
- Remove unused `config_fail` method that I stopped calling in the last PR but forgot to delete
- Remove environment variables from the Dockerfile that no longer do anything